### PR TITLE
ClassHierarchy: if a class is not found in subclasses/superclasses, return empty set instead of exception

### DIFF
--- a/src/demo/de/tud/cs/st/bat/resolved/analyses/ClassHierarchy.scala
+++ b/src/demo/de/tud/cs/st/bat/resolved/analyses/ClassHierarchy.scala
@@ -81,13 +81,13 @@ class ClassHierarchy {
      * that directly inherit from the given type.
      */
     def subclasses(objectType: ObjectType): immutable.Set[ObjectType] =
-        subclasses.apply(objectType).toSet
+        subclasses.getOrElse(objectType, Set.empty).toSet
 
     /**
      * The classes and interfaces from which the given type directly inherits.
      */
     def superclasses(objectType: ObjectType): immutable.Set[ObjectType] =
-        superclasses.apply(objectType).toSet
+        superclasses.getOrElse(objectType, Set.empty).toSet
 
     /**
      * The classes and interfaces from which the given types directly inherit.


### PR DESCRIPTION
I got this problem while analyzing a jar which was not using Serializable and with a lookup for subclasses("java/io/Serializable"), and now it's solved.

The stacktrace (perhaps mangled) was this one:
java.util.NoSuchElementException: key not found: ObjectType(className="java/io/Serializable")
        at scala.collection.MapLike$class.default(MapLike.scala:224)
        at scala.collection.mutable.HashMap.default(HashMap.scala:43)
        at scala.collection.MapLike$class.apply(MapLike.scala:135)
        at scala.collection.mutable.HashMap.apply(HashMap.scala:43)
        at de.tud.cs.st.bat.resolved.analyses.ClassHierarchy.subclasses(ClassHierarchy.scala:84)
        at de.tud.cs.st.bat.resolved.analyses.Main$.analyze(Main.scala:156)
        at de.tud.cs.st.bat.resolved.analyses.Main$.main(Main.scala:77)
        at de.tud.cs.st.bat.resolved.analyses.Main.main(Main.scala)
