### PR TITLE
Bugfix: the version test was unlike FindBugs's

### DIFF
--- a/demo/src/main/scala/de/tud/cs/st/bat/resolved/analyses/BX_BOXING_IMMEDIATELY_UNBOXED_TO_PERFORM_COERCION.scala
+++ b/demo/src/main/scala/de/tud/cs/st/bat/resolved/analyses/BX_BOXING_IMMEDIATELY_UNBOXED_TO_PERFORM_COERCION.scala
@@ -19,7 +19,7 @@ object BX_BOXING_IMMEDIATELY_UNBOXED_TO_PERFORM_COERCION
     // Integer.valueOf(1).doubleValue()
     def analyze(project: Project) = {
         val classFiles: Traversable[ClassFile] = project.classFiles
-        for (classFile ← classFiles if classFile.majorVersion > 49;
+        for (classFile ← classFiles if classFile.majorVersion >= 49;
              method ← classFile.methods if method.body.isDefined;
              Seq(
              (INVOKESPECIAL(firstReceiver, _ , MethodDescriptor(Seq(paramType), _)), _),


### PR DESCRIPTION
While we test `majorVersion > 49`, FindBugs tests
`obj.getMajor() >= MAJOR_1_5`, and MAJOR_1_5 = 49, as shown below:

http://commons.apache.org/bcel/apidocs/src-html/org/apache/bcel/Constants.html#line.71

Apparently, I have a JDK 1.6 where all violations are in classfiles in
1.5 format, so that this bug hid all of them.

Backported from:
https://github.com/ps-mr/LinqOnSteroids/commit/10d5b39db1ccc22c08d3f445b251bc9b566dfc7d
